### PR TITLE
Update caravagene.py

### DIFF
--- a/caravagene/caravagene.py
+++ b/caravagene/caravagene.py
@@ -322,6 +322,7 @@ class ConstructList:
         process = sp.Popen(
             [
                 "wkhtmltopdf",
+                "--enable-local-file-access",
                 "--quiet",
                 "--page-size",
                 self.page_size,
@@ -355,6 +356,7 @@ class ConstructList:
         process = sp.Popen(
             [
                 "wkhtmltoimage",
+                "--enable-local-file-access",
                 "--format",
                 extension,
                 "--width",


### PR DESCRIPTION
- allow disk access to the wkhtml* cli args.
- this was required for this to work on Macos